### PR TITLE
Fix RelationList widget for slider_relation field.  Fixes #1.

### DIFF
--- a/src/collective/behavior/banner/slider.py
+++ b/src/collective/behavior/banner/slider.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 from collective.behavior.banner import _
 from collective.behavior.banner.banner import IBanner
+from plone.app.z3cform.widget import RelatedItemsFieldWidget
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.autoform import directives as form
-from plone.formwidget.contenttree import MultiContentTreeFieldWidget
 from plone.formwidget.contenttree import ObjPathSourceBinder
 from plone.supermodel import model
-from z3c.relationfield.schema import RelationChoice, RelationList
+from z3c.relationfield.schema import RelationChoice
+from z3c.relationfield.schema import RelationList
 from zope.component import adapts
-from zope.interface import alsoProvides, implements
+from zope.interface import alsoProvides
+from zope.interface import implements
 
 
 class ISlider(model.Schema):
@@ -22,8 +24,8 @@ class ISlider(model.Schema):
         ]
     )
 
-    form.widget(
-        slider_relation=MultiContentTreeFieldWidget)
+    form.widget('slider_relation', RelatedItemsFieldWidget,
+                vocabulary='plone.app.vocabularies.Catalog')
     slider_relation = RelationList(
         title=_(u"Slider Banners"),
         description=_(u"These banners will be used in the slider"),


### PR DESCRIPTION
This gets rid of the javascript issue, so the relation widget works.  But it does not filter by content providing `IBanner`.  I could not figure out how to make that work.
Note that if I browse to `http://localhost:8080/Plone/news/++add++News%20Item/++widget++form.widgets.ISlider.slider_relation/@@getSource`, I correctly get just the content that provides `IBanner`.
