### PR TITLE
Added functionality: make compatible with plone.app.imagecropping

### DIFF
--- a/src/collective/behavior/banner/banner.py
+++ b/src/collective/behavior/banner/banner.py
@@ -29,6 +29,7 @@ class IBanner(model.Schema):
             'banner_link',
             'banner_linktext',
             'banner_fontcolor',
+            'banner_backgroundcolor',
         ]
     )
 
@@ -97,6 +98,12 @@ class IBanner(model.Schema):
     banner_fontcolor = schema.TextLine(
         title=_(u'Fontcolor on the teaser'),
         description=_(u'Color for headings and texts as webcolor'),
+        required=False,
+    )
+
+    banner_backgroundcolor = schema.TextLine(
+        title=_(u'Background color'),
+        description=_(u'Background color on the banner'),
         required=False,
     )
 

--- a/src/collective/behavior/banner/browser/banner.pt
+++ b/src/collective/behavior/banner/browser/banner.pt
@@ -6,7 +6,10 @@
      tal:define="has_image python:banner and 'banner_image' in banner;
                  has_url python:banner and 'banner_url' in banner;
                  has_fontcolor python:banner and 'banner_fontcolor' in banner;
-                 fontcolor python:has_fontcolor and banner['banner_fontcolor'] + ' !important' or '#4d4d4d'">
+                 fontcolor python:has_fontcolor and banner['banner_fontcolor'] + ' !important' or '#4d4d4d';
+                 has_backgroundcolor python:banner and 'banner_backgroundcolor' in banner;
+                 backgroundcolor python:has_backgroundcolor and 'background:' + banner['banner_backgroundcolor'] + ' !important' or ''"
+     tal:attributes="style backgroundcolor">
 
     <div class="container"
         tal:condition="python: banner">

--- a/src/collective/behavior/banner/browser/banner.pt
+++ b/src/collective/behavior/banner/browser/banner.pt
@@ -17,7 +17,7 @@
                 <div class="bannerImage"
                      tal:condition="python:has_image">
                         <img class="bannerImageImage"
-                             tal:attributes="src string:${banner/banner_image}/preview">
+                             tal:attributes="src string:${banner/banner_image}/${view/banner_scale}">
                 </div>
 
                 <div class="bannerVideo"

--- a/src/collective/behavior/banner/browser/configure.zcml
+++ b/src/collective/behavior/banner/browser/configure.zcml
@@ -10,6 +10,10 @@
       directory="static"
       />
 
+    <utility
+      factory=".controlpanel.SizesVocabulary"
+      name="collective.behavior.banner.all_sizes" />
+
     <browser:viewlet
       name="collective.bannerviewlet"
       for="plone.dexterity.interfaces.IDexterityContent"

--- a/src/collective/behavior/banner/browser/controlpanel.py
+++ b/src/collective/behavior/banner/browser/controlpanel.py
@@ -1,8 +1,21 @@
 # -*- coding: UTF-8 -*-
+from plone.app.imaging.utils import getAllowedSizes
 from plone.app.registry.browser import controlpanel
 from Products.CMFPlone import PloneMessageFactory as _
 from zope import schema
 from zope.interface import Interface
+from zope.interface import implementer
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+@implementer(IVocabularyFactory)
+class SizesVocabulary(object):
+
+    def __call__(self, context):
+        allowed_sizes = getAllowedSizes()
+        size_names = allowed_sizes and allowed_sizes.keys() or []
+        return SimpleVocabulary.fromValues(size_names)
 
 
 class IBannerSettingsSchema(Interface):
@@ -24,6 +37,14 @@ class IBannerSettingsSchema(Interface):
             'Link',
             'News Item',
         ]
+    )
+
+    banner_scale = schema.Choice(
+        title=_(u'Banner scale'),
+        description=_(u'Scale at which banner images are displayed'),
+        required=True,
+        default='preview',
+        vocabulary='collective.behavior.banner.all_sizes',
     )
 
 

--- a/src/collective/behavior/banner/browser/viewlets.py
+++ b/src/collective/behavior/banner/browser/viewlets.py
@@ -66,7 +66,9 @@ class BannerViewlet(ViewletBase):
 
     def banner_scale(self):
         return api.portal.get_registry_record(
-            'collective.behavior.banner.browser.controlpanel.IBannerSettingsSchema.banner_scale')
+            'collective.behavior.banner.browser.controlpanel.IBannerSettingsSchema.banner_scale',
+            default='preview'
+        )
 
     def banner(self, obj):
         """ return banner of this object """

--- a/src/collective/behavior/banner/browser/viewlets.py
+++ b/src/collective/behavior/banner/browser/viewlets.py
@@ -39,7 +39,7 @@ class BannerViewlet(ViewletBase):
             if context.banner_hide:
                 return False
             banner = self.banner(context)
-            if banner:
+            if 'banner_url' in banner or 'banner_image' in banner:
                 return banner
             if context.banner_stop_inheriting:
                 return False
@@ -55,7 +55,7 @@ class BannerViewlet(ViewletBase):
                 if item.banner_stop_inheriting:
                     return False
                 banner = self.banner(item)
-                if banner:
+                if 'banner_url' in banner or 'banner_image' in banner:
                     return banner
             if INavigationRoot.providedBy(item):
                 return False

--- a/src/collective/behavior/banner/browser/viewlets.py
+++ b/src/collective/behavior/banner/browser/viewlets.py
@@ -64,6 +64,10 @@ class BannerViewlet(ViewletBase):
 
         return False
 
+    def banner_scale(self):
+        return api.portal.get_registry_record(
+            'collective.behavior.banner.browser.controlpanel.IBannerSettingsSchema.banner_scale')
+
     def banner(self, obj):
         """ return banner of this object """
         banner = {}

--- a/src/collective/behavior/banner/browser/viewlets.py
+++ b/src/collective/behavior/banner/browser/viewlets.py
@@ -39,7 +39,8 @@ class BannerViewlet(ViewletBase):
             if context.banner_hide:
                 return False
             banner = self.banner(context)
-            if 'banner_url' in banner or 'banner_image' in banner:
+            config_keys = [key for key in banner.keys() if key != 'banner_obj']
+            if config_keys:
                 return banner
             if context.banner_stop_inheriting:
                 return False
@@ -55,7 +56,8 @@ class BannerViewlet(ViewletBase):
                 if item.banner_stop_inheriting:
                     return False
                 banner = self.banner(item)
-                if 'banner_url' in banner or 'banner_image' in banner:
+                config_keys = [key for key in banner.keys() if key != 'banner_obj']
+                if config_keys:
                     return banner
             if INavigationRoot.providedBy(item):
                 return False
@@ -92,6 +94,8 @@ class BannerViewlet(ViewletBase):
             banner['banner_linktext'] = obj.banner_linktext
         if obj.banner_fontcolor:
             banner['banner_fontcolor'] = obj.banner_fontcolor
+        if obj.banner_backgroundcolor:
+            banner['banner_backgroundcolor'] = obj.banner_backgroundcolor
         if obj.banner_url:
             banner['banner_url'] = obj.banner_url
         banner['banner_obj'] = obj

--- a/src/collective/behavior/banner/configure.zcml
+++ b/src/collective/behavior/banner/configure.zcml
@@ -17,6 +17,14 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:upgradeStep
+      title="collective.behavior.banner: Add banner_scale to registry"
+      source="1"
+      destination="2"
+      handler=".upgradehandlers.upgrade_registry_for_banner_scale"
+      profile="collective.behavior.banner:default"
+      />
+
   <genericsetup:importStep
       name="collective.behavior.banner-postInstall"
       title="collective.behavior.banner post_install import step"

--- a/src/collective/behavior/banner/profiles/default/metadata.xml
+++ b/src/collective/behavior/banner/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1</version>
+  <version>2</version>
 </metadata>

--- a/src/collective/behavior/banner/upgradehandlers.py
+++ b/src/collective/behavior/banner/upgradehandlers.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+from Products.CMFPlone import PloneMessageFactory as _
+from plone.registry import field
+from plone.registry import Record
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+
+
+def upgrade_registry_for_banner_scale(context):
+    key_id = 'collective.behavior.banner.browser.controlpanel.IBannerSettingsSchema.banner_scale'
+    registry = getUtility(IRegistry)
+    records = registry.records
+    if key_id in records:
+        return
+
+    record = Record(
+        field.Choice(
+            title=_(u'Banner scale'),
+            description=_(u'Scale at which banner images are displayed'),
+            required=True,
+            vocabulary='collective.behavior.banner.all_sizes',
+            default='preview'),
+        value='preview')
+    records[key_id] = record


### PR DESCRIPTION
https://github.com/collective/plone.app.imagecropping

There's a new element in the config panel, banners can be cropped to a different scale than "preview".

Note: commit aacd2bb fixes an edge case introduced by 4b34331: since banner() now returns a dict with at least one key, lines after "if banner:" become useless.