### PR TITLE
Define a global banner

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 - Steffen Lindner, lindner@starzel.de
 - Stefan Antonelli, stefan.antonelli@operun.de
 - Fulvio Casali, fulviocasali@gmail.com
+- Valentin Piret, valentin@affinitic.be

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -6,7 +6,8 @@ Changelog
 1.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Use the banner from the root default content if there is one
+  [Vaal24]
 
 
 1.0 (2018-08-16)

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -18,13 +18,13 @@ Banner
 
 A banner is usually some text and an image that is displayed above of the content.
 
-The behavior ``collective.behavior.banner.banner.IBanner`` has various fields (image, title, subtitle, richtext, link, linkcaption etc) that are combined to build a banner. You can enable the behavior on any Dexterity type (tested with plone.app.contenttypes).
+The behavior ``collective.behavior.banner.banner.IBanner`` has various fields (image, title, subtitle, richtext, link, linkcaption etc) that are combined to build a banner. You can enable the behavior on any Dexterity type (tested with plone.app.contenttypes) or for the whole Plone site.
 
 
 Slider
 ------
 
-The behavior ``collective.behavior.banner.slider.ISlider`` adds the option to add relations to several banners (i.e. items that have the Banner behavior enabled). These banners are then displayed like a banner but fade .
+The behavior ``collective.behavior.banner.slider.ISlider`` adds the option to add relations to several banners (i.e. items that have the Banner behavior enabled). These banners are then displayed like a banner but fade.
 
 The slider viewlet uses the javascript library http://responsiveslides.com and fades from one banner to another. You can easily use a different javascript libray by overriding the viewlet templates (see below).
 
@@ -34,7 +34,7 @@ Before you use a slider/carousel on your website, please take time to read http:
 Inheriting
 ----------
 
-Banners are inherited by child objects. In a controlpanel you can configure which types should display inherited banners. You can also prevent inheriting banners for an item and its child objects by enabling the option *Do not inherit banner from parents* on the banner tab.
+Banners are inherited by child objects. In a controlpanel you can configure which types should display inherited banners. You can also prevent inheriting banners for an item and its child objects by enabling the option *Do not inherit banner from parents* on the banner tab. If you want a banner for the entire site, you can assign one to the default content of the Navigation Root (or Plone site root).
 
 
 Customization

--- a/src/collective/behavior/banner/browser/viewlets.py
+++ b/src/collective/behavior/banner/browser/viewlets.py
@@ -61,6 +61,10 @@ class BannerViewlet(ViewletBase):
                 if config_keys:
                     return banner
             if INavigationRoot.providedBy(item):
+                if getattr(item, item.default_page):
+                    banner = self.banner(getattr(item, item.default_page))
+                    if banner:
+                        return banner
                 return False
             if item.portal_type not in types:
                 return False


### PR DESCRIPTION
If you want a banner for the entire site, you can assign one to the default content of the Navigation Root (or Plone site root). #24 